### PR TITLE
remove call to clear source files from target

### DIFF
--- a/lib/j2objc_shared_lib_smanger.rb
+++ b/lib/j2objc_shared_lib_smanger.rb
@@ -27,7 +27,7 @@ module IntegrateJ2objc
 			added_references.each do |f|
 				puts "\t#{f.hierarchy_path}"
 			end
-			target_obj.source_build_phase.clear
+			# target_obj.source_build_phase.clear
 			target_obj.add_file_references(added_references)
 
 			current_project.save


### PR DESCRIPTION
I've no idea why this call is made - it seems to just remove all source from the target, where this is not necessary, and in fact detrimental, if you want your target to already contain some source code :)

Please see https://github.com/developertown/integratej2objc/issues/16 for details.
